### PR TITLE
Fix reference to formField

### DIFF
--- a/assets/scripts/libs/VueHelpers.mjs
+++ b/assets/scripts/libs/VueHelpers.mjs
@@ -3,7 +3,7 @@ const localize = (stringId, data={}) => {
 };
 
 const formField = (field, options) => {
-	return HandlebarsHelpers.formField(field, options);
+	return HandlebarsHelpers.formGroup(field, options);
 }
 
 export { localize, formField };


### PR DESCRIPTION
Foundry only declares formField as an alias in Handlebars.helpers. 

```javascript
// Register all handlebars helpers
Handlebars.registerHelper({
  ...
  formGroup: HandlebarsHelpers.formGroup,
  formField: HandlebarsHelpers.formGroup, // Alias
  ...
```

✅ `Handlebars.helpers.formGroup`
✅ `Handlebars.helpers.formField`
✅ `HandlebarsHelpers.formGroup`
❌ `HandlebarsHelpers.formField`

